### PR TITLE
Cleanup filetype detection commands

### DIFF
--- a/ftdetect/snakemake.vim
+++ b/ftdetect/snakemake.vim
@@ -1,5 +1,4 @@
-au BufNewFile,BufRead Snakefile set syntax=snakemake | set filetype=snakemake
-au BufNewFile,BufRead *.rules set syntax=snakemake | set filetype=snakemake
-au BufNewFile,BufRead *.snakefile set syntax=snakemake | set filetype=snakemake
-au BufNewFile,BufRead *.snake set syntax=snakemake | set filetype=snakemake
-au BufNewFile,BufRead *.smk set syntax=snakemake | set filetype=snakemake
+augroup VimSnakemake
+  autocmd!
+  autocmd BufNewFile,BufRead Snakefile,*.snakefile,*.snake,*.smk setlocal filetype=snakemake
+augroup END


### PR DESCRIPTION
1. Drop `syntax=` declaration in favor of just setting `filetype=`. If filetype is set properly, also setting syntax shouldn't be necessary. Even if it was, the extra command `| set` isn't necessary, you can set more than one variable from a single set.

2. Use augroup. _Always_ place automd's inside an augroup, otherwise reloading plugins on a config change is problematic.

3. Simplify to a single autocmd.

4. Use `setlocal` so we don't disturb other buffers, especially ones where users may have overridden this detection.

5. Drop `*.rules`, this match conflicts with several other potential filetypes. If this is a common thing to use with snakemake you'll want to do some content inspection and make sure it's actually what you think it is, not for example a CSV import rules spec file.